### PR TITLE
Create Chip component

### DIFF
--- a/src/components/chip.css
+++ b/src/components/chip.css
@@ -1,0 +1,25 @@
+.orange-chip {
+    display: inline-flex;
+    flex: 1 1 auto;
+    align-items: center;
+    background: white;
+    box-sizing: border-box;
+    border: 1px solid black;
+    border-radius: 24px;
+    padding: 8px 22px 8px 24px;
+    margin: 8px 8px;
+    width: fit-content;
+}
+
+.orange-chip.active {
+    border-color: orange;
+    background: orange;
+}
+
+.orange-chip.inactive:hover {
+    background: lightgray;
+}
+
+.orange-chip-svg:hover {
+    fill: gray;
+}

--- a/src/components/chip.js
+++ b/src/components/chip.js
@@ -1,0 +1,36 @@
+import React from "react";
+import "./chip.css";
+
+const Chip = props => {
+    const handleClick = event => {
+        event.stopPropagation();
+        props.onDelete()
+    };
+
+    return (
+        <span className={`orange-chip ${props.state}`} onClick={props.onClick}>
+            {props.children}
+            {props.state === "active" ? <svg height="20" width="28">
+                <g
+                    className="orange-chip-svg"
+                    fill="black"
+                    onClick={handleClick}
+                >
+                    <circle cx="60%" cy="50%" r="10" />
+                    <text
+                        x="60%"
+                        y="50%"
+                        textAnchor="middle"
+                        fill="white"
+                        strokeWidth="1"
+                        dy=".3em"
+                        fontSize="11px"
+                    >
+                        ✕
+                    </text>
+                </g>
+            </svg> : null}
+        </span>
+    );
+};
+export default Chip;

--- a/src/components/chip.js
+++ b/src/components/chip.js
@@ -23,10 +23,10 @@ const Chip = props => {
                         textAnchor="middle"
                         fill="white"
                         strokeWidth="1"
-                        dy=".3em"
-                        fontSize="11px"
+                        dy=".27em"
+                        fontSize="20px"
                     >
-                        ✕
+                        &times;
                     </text>
                 </g>
             </svg> : null}

--- a/src/pages/toolsPage.css
+++ b/src/pages/toolsPage.css
@@ -1,19 +1,3 @@
-
-button {
-    margin: 0.5em;
-    padding: 0.7em 1.5em;
-    border-style: solid;
-    border-radius: 1.5em;
-    border-width: 1px;
-    border-color: black;
-    background: white;
-}
-
-button.active {
-    border-color: orange;
-    background: orange;
-}
-
 .learnmore a {
     display: inline-block;
     color: black;

--- a/src/pages/toolsPage.js
+++ b/src/pages/toolsPage.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from "react";
 import "./toolsPage.css";
 
 import Card from "../components/card";
+import Chip from "../components/chip";
 import Logo from "../logo.svg";
 
 const ImgThirdEyeGenX2 = "/images/headsets/moverioBT300.jpg";
@@ -30,14 +31,19 @@ class ToolsPage extends Component {
         super(props);
 
         this.state = {
-            filter: new Map(buttonData.map(data => [data, true])),
+            chips: [],
             toolType: "Hardware"
         };
     }
 
-    updateFilter = d => {
-        this.state.filter.set(d, !this.state.filter.get(d));
-        this.setState({ filter: this.state.filter });
+    handleClick = data => {
+        const newChips = [...this.state.chips, data];
+        this.setState({ chips: newChips });
+    };
+
+    handleDelete = data => {
+        const newChips = this.state.chips.filter(chip => chip !== data);
+        this.setState({ chips: newChips });
     };
 
     render() {
@@ -49,30 +55,51 @@ class ToolsPage extends Component {
                 <div className="body">
                     <h1>{this.state.toolType} Tools</h1>
 
-                    {buttonData.map(data => {
-                        const button_state = this.state.filter.get(data)
-                            ? "active"
-                            : "";
-                        return (
-                            <button
-                                className={button_state}
-                                onClick={this.updateFilter.bind(this, data)}
-                            >
-                                {data}
-                            </button>
-                        );
-                    })}
+                    <div className="toolspage-chips">
+                        {buttonData.map(data => {
+                            return (
+                                <Chip
+                                    state={
+                                        this.state.chips.includes(data)
+                                            ? "active"
+                                            : "inactive"
+                                    }
+                                    onClick={this.handleClick.bind(this, data)}
+                                    onDelete={this.handleDelete.bind(
+                                        this,
+                                        data
+                                    )}
+                                >
+                                    {data}
+                                </Chip>
+                            );
+                        })}
+                    </div>
 
-                    {pageData.map(categoryData => (
-                        <div>
-                            <h2>{categoryData.category}</h2>
-                            <Grid
-                                data={categoryData.data.filter(d =>
-                                    this.state.filter.get(d.type)
-                                )}
-                            />
-                        </div>
-                    ))}
+                    {tools.map(toolByCategory => {
+                        if (
+                            this.state.chips.length === 0 ||
+                            this.state.chips.includes(toolByCategory.category)
+                        ) {
+                            return (
+                                <div>
+                                    <h2>{toolByCategory.category}</h2>
+                                    <Grid
+                                        data={
+                                            this.state.chips.length === 0
+                                                ? toolByCategory.data
+                                                : toolByCategory.data.filter(
+                                                      tool =>
+                                                          this.state.chips.includes(
+                                                              tool.type
+                                                          )
+                                                  )
+                                        }
+                                    />
+                                </div>
+                            );
+                        }
+                    })}
                 </div>
             </Fragment>
         );
@@ -97,7 +124,7 @@ const buttonData = [
 
 const gridText =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sagittis orci a scelerisque purus semper. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ";
-const pageData = [
+const tools = [
     {
         category: "Head-mounted Displays",
         data: [


### PR DESCRIPTION
The AR tools page is updated with the new Chip component. Think of Chip component as a button with an extra delete button.

<img width="805" alt="Screen Shot 2020-04-03 at 12 24 39 AM" src="https://user-images.githubusercontent.com/40753283/78327040-84d38480-7541-11ea-9926-254483d24913.png">

There are four properties for the Chip component.
state: active or inactive, where active will show the orange colored button with the delete button.
onClick: same as any other onClick event.
onDelete: custom onClick event for the circle with cross mark. 
children: anything in between the component, in this case, {data}
```js 
<Chip 
    state={this.state.chips.includes(data) ? "active" : "inactive"}
    onClick={this.handleClick.bind(this, data)}
    onDelete={this.handleDelete.bind(this, data)}>
    {data}
</Chip>
```

The tools page now correctly displays everything as the default, but also only displays categories that are selected once one of the categories are selected.